### PR TITLE
Added missing command line option in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ log_freq: 20
 
 These can easily be changed via the command line, and a search space of different parameters can also be explored:
 ```
-$ python ./dqn.py discount_factor=0.99 use_target_net=False,True update_target_freq=2000 sample_memory=False,True num_episodes=700 env="Acrobot-v1" seed=24,23,22,21,20,19,18,17
+$ python ./dqn.py --multirun discount_factor=0.99 use_target_net=False,True update_target_freq=2000 sample_memory=False,True num_episodes=700 env="Acrobot-v1" seed=24,23,22,21,20,19,18,17
 ```
 
 Each experiment will result in a new subdirectory to be created under `./experiments/`.


### PR DESCRIPTION
Running the command
`python ./dqn.py discount_factor=0.99 use_target_net=False,True update_target_freq=2000 sample_memory=False,True num_episodes=700 env="Acrobot-v1" seed=24,23,22,21,20,19,18,17`
resulted in the following error:
```
False,True update_target_freq=2000 sample_memory=False,True num_episodes=700 env="Acrobot-v1" seed=24,23,22,21,20,19,18,17
Ambiguous value for argument 'use_target_net=False,True'
1. To use it as a list, use key=[value1,value2]
2. To use it as string, quote the value: key=\'value1,value2\'
3. To sweep over it, add --multirun to your command line

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```
Fixed it according to the documentation [here](https://hydra.cc/docs/intro/). I am using Hydra 1.0.7 for reference.
